### PR TITLE
Add PDF server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ await thart({
 });
 ```
 
+View more examples in the [examples](examples) directory.
+
 ## API
 
 ### thart(options)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+This directory contains example projects that demonstrate more complex usage of thart.

--- a/examples/pdf-server/README.md
+++ b/examples/pdf-server/README.md
@@ -1,0 +1,30 @@
+# PDF server example
+This is a simple example of running a server using thart in cluster mode with 4 workers.
+
+The server reads a PDF file and returns the text content of the first page.
+
+Get started:
+```bash
+npm i  # or pnpm/yarn if you prefer
+npm start
+```
+
+You should see four workers start up:
+```
+Worker 0 running with pid XXXX
+Worker 1 running with pid XXXX
+Worker 3 running with pid XXXX
+Worker 2 running with pid XXXX
+```
+
+Next, make a request using curl (or any http client you prefer):
+```bash
+curl -X POST -H "Content-Type: application/pdf" --data-binary @document.pdf http://localhost:3000/
+```
+
+The worker handling the request will log its pid and respond with something like:
+```json
+{
+  "text": "This is the text content of the first page."
+}
+```

--- a/examples/pdf-server/package-lock.json
+++ b/examples/pdf-server/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "thart",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "thart",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "mupdf": "^0.3.0",
+        "thart": "^0.1.0"
+      }
+    },
+    "node_modules/mupdf": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mupdf/-/mupdf-0.3.0.tgz",
+      "integrity": "sha512-SnTNxFV0+5z+01yWPByxvyTDGkBalyTeVTr2FxLJlWFf/isKiI6GIYrEiv+aggU3tHXu6a9l1yyCvdA5nhPOQA==",
+      "license": "AGPL-3.0-or-later"
+    },
+    "node_modules/thart": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/thart/-/thart-0.1.0.tgz",
+      "integrity": "sha512-JwovXKprqa63fptRGrECzyGD4xrdu2DBiE/0x6XYA1nnNBjpfXfu1gyLdP2aMxIm2nJVeDvbM8mNUpwWAC+B/Q=="
+    }
+  }
+}

--- a/examples/pdf-server/package.json
+++ b/examples/pdf-server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "thart",
+  "version": "1.0.0",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "mupdf": "^0.3.0",
+    "thart": "^0.1.0"
+  },
+  "type": "module"
+}

--- a/examples/pdf-server/server.js
+++ b/examples/pdf-server/server.js
@@ -1,0 +1,47 @@
+/**
+ * This is a simple example of running a server using thart in cluster mode with 4 workers.
+ * The server reads a PDF file and returns the text content of the first page.
+ *
+ * Example request:
+ * curl -X POST -H "Content-Type: application/pdf" --data-binary @document.pdf http://localhost:3000/
+ *
+ * Example response: {"text":"This is the text content of the first page."}
+ */
+import http from "http";
+
+import { Document } from "mupdf";
+import { thart } from "thart";
+
+const server = () =>
+  http.createServer(async (req, res) => {
+    console.log(`Process ${process.pid} handling request`);
+    if (
+      req.method === "POST" &&
+      req.headers["content-type"] === "application/pdf"
+    ) {
+      // read file into a buffer
+      const file = await new Promise((resolve) => {
+        const chunks = [];
+        req.on("data", (chunk) => chunks.push(chunk));
+        req.on("end", () => resolve(Buffer.concat(chunks)));
+      });
+      const document = Document.openDocument(file, "application/pdf");
+      const text = document.loadPage(0).toStructuredText().asText();
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ text }));
+    } else {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Only PDF uploads are supported." }));
+    }
+  });
+
+await thart({
+  worker: {
+    count: 4,
+    type: "cluster",
+    start: (id) => {
+      console.log(`Worker ${id} running with pid ${process.pid}`);
+      new Promise((resolve) => server().listen(3000, resolve));
+    },
+  },
+});


### PR DESCRIPTION
- Add an `examples/` directory.
- Add a example server running in a thart cluster.